### PR TITLE
Fix bug of articles not being correctly returned

### DIFF
--- a/src/lib/getAllArticles.js
+++ b/src/lib/getAllArticles.js
@@ -23,8 +23,9 @@ const fetchArticleFilenames = async () =>
 
 export const getAllArticles = async () => {
   const articleFilenames = await fetchArticleFilenames()
-
-  const articles = await Promise.all(articleFilenames.map(importArticle))
+  const articles = await Promise.all(
+    articleFilenames.map((filename) => importArticle(filename))
+  )
 
   return articles.sort((a, z) => new Date(z.date) - new Date(a.date))
 }


### PR DESCRIPTION
The `pathOnly` argument was being set to true for the second article, so was returning just the article path, rather than the article.