### PR TITLE
Fix photo flicker bug

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "next/core-web-vitals",
   "rules": {
-    "react/no-unescaped-entities": "off"
+    "react/no-unescaped-entities": "off",
+    "@next/next/no-img-element": "off"
   }
 }

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -1,8 +1,5 @@
-// FIXME: There's a momentary flash of an incorrectly sized image when switching between images of different sizes
-// No idea what's causing it, but try adding transitions when scrolling between images. They'd be nice to have anyway, and could fix it.
-
 import { useEffect, useState } from 'react'
-import Image from 'next/image'
+// import Image from 'next/image'
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/solid'
 
 import useScreenWidth from '@/hooks/use-screen-width'
@@ -75,12 +72,13 @@ const ImageGallery = ({ images }) => {
           )}
         </div>
         <div className="flex h-full items-center justify-center">
-          <Image
+          {/* <Image
             src={images[imageIndex].src}
             alt={images[imageIndex].alt}
             height={galleryHeight}
             unoptimized
-          />
+          /> */}
+          <img src={images[imageIndex].src.src} alt={images[imageIndex].alt} />
         </div>
       </div>
       <LinkWrapper url={images[imageIndex].url}>


### PR DESCRIPTION
Updates the image gallery to use `<img>` rather than Next.js's `<Image>` tag.

I would rather use the `<Image>` tag to stay consistent with using Next.js, so I'll term this a "temporary" solution (yeah right) and have left the `<Image>` code in there, commented-out. However, in previous projects I've found the `<Image>` tag to be very buggy (and to also use a lot of resources when hosting with Vercel), so it might be a long-term temporary solution.

Using the `<img>` tag fixes the bug of a flicker when changing between images of different sizes.