### PR TITLE
Update image gallery

### DIFF
--- a/src/components/Header/Avatar/index.jsx
+++ b/src/components/Header/Avatar/index.jsx
@@ -14,7 +14,8 @@ const Avatar = ({ large = false, className, ...props }) => {
     >
       <Image
         src={avatarImage}
-        alt=""
+        alt="Jethro Williams avatar"
+        title=""
         sizes={large ? '4rem' : '2.25rem'}
         className={clsx(
           'rounded-full bg-zinc-100 object-cover dark:bg-zinc-800',

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -1,11 +1,4 @@
-// TODO: Update this so that all images load by default?
-// So, for example, the images are all present, but hidden
-// This would have 2 benefits:
-// 1) They would load instantly when scrolling through the image gallery
-// 2) All images would be available for Google; presently only the first image appears in the page source
-
 import { useEffect, useState } from 'react'
-// import Image from 'next/image'
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/solid'
 
 import useScreenWidth from '@/hooks/use-screen-width'
@@ -78,17 +71,14 @@ const ImageGallery = ({ images }) => {
           )}
         </div>
         <div className="flex h-full items-center justify-center">
-          {/* <Image
-            src={images[imageIndex].src}
-            alt={images[imageIndex].alt}
-            height={galleryHeight}
-            unoptimized
-          /> */}
-          <img
-            src={images[imageIndex].src.src}
-            alt={images[imageIndex].alt}
-            className="h-full"
-          />
+          {images.map((image, index) => (
+            <img
+              key={image.src.src}
+              src={image.src.src}
+              alt={image.alt}
+              className={`h-full${index === imageIndex ? '' : ' hidden'}`}
+            />
+          ))}
         </div>
       </div>
       <LinkWrapper url={images[imageIndex].url}>

--- a/src/components/SimpleLayout.jsx
+++ b/src/components/SimpleLayout.jsx
@@ -7,9 +7,11 @@ const SimpleLayout = ({ title, intro, children }) => {
         <h1 className="text-4xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:text-5xl">
           {title}
         </h1>
-        <p className="mt-6 text-base text-zinc-600 dark:text-zinc-400">
-          {intro}
-        </p>
+        {intro && (
+          <p className="mt-6 text-base text-zinc-600 dark:text-zinc-400">
+            {intro}
+          </p>
+        )}
       </header>
       <div className="mt-16 sm:mt-20">{children}</div>
     </Container>

--- a/src/pages/about/index.jsx
+++ b/src/pages/about/index.jsx
@@ -6,7 +6,7 @@ import clsx from 'clsx'
 import { Container } from '@/components/Container'
 import portraitImage from './portrait.jpg'
 
-const Heading = "I'm Jethro. I'm a digital nomad."
+const Heading = "I'm Jethro, I'm a digital nomad."
 
 const SocialLink = ({ className, href, children, icon: Icon }) => {
   return (
@@ -46,7 +46,7 @@ const About = () => {
             <div className="max-w-xs px-2.5 lg:max-w-none">
               <Image
                 src={portraitImage}
-                alt=""
+                alt="On Bui Vien Walking Street in Ho Chi Minh City"
                 sizes="(min-width: 1024px) 32rem, 20rem"
                 className="aspect-square rotate-3 rounded-2xl bg-zinc-100 object-cover dark:bg-zinc-800"
               />
@@ -59,7 +59,7 @@ const About = () => {
             <div className="mt-6 space-y-7 text-base text-zinc-600 dark:text-zinc-400">
               <p>
                 That's just a fancy way of saying I'm not grown up enough to
-                settle down and start being an adult yet, and that I'm too lazy
+                settle down and start being an adult yet, but that I'm too lazy
                 to travel properly, so spend several weeks or even months
                 staying everywhere I go.
               </p>
@@ -67,7 +67,7 @@ const About = () => {
                 I work as a freelance software engineer, so I can earn a living
                 from anywhere with an Internet connection. I'm a big believer in
                 not working too much, and have found that I can work two days
-                per week, and still save money, so I don't really do any more.
+                per week and still save money, so I don't really do any more.
               </p>
               <p>
                 I'm also vegan, I run, I don't have many friends, I'm scared of
@@ -87,16 +87,16 @@ const About = () => {
                 myself that I'm doing some good in the world.
               </p>
               <p>
-                This isn't a backpacking blog. I've spent more than my share of
-                time living out of a backpack, staying in hostel dorms,
-                Couchsurfing before the perverts ruined it, camping at the side
-                of the road, and even sleeping under the stars occasionally,
-                which is another way of saying I slept rough because I was too
-                cheap to pay for a hostel.
+                This isn't a backpacking blog. I've paid my dues as a
+                backpacker, with years of staying in hostel dorms, Couchsurfing
+                before the perverts ruined it, camping at the side of the road,
+                and even sleeping under the stars occasionally, which is another
+                way of saying I slept rough because I was too cheap to pay for a
+                hostel.
               </p>
               <p>
                 I cherish those days, but they are long behind me. As a digital
-                nomad, I don't need to save every penny that I can, because I'm
+                nomad, I don't need to save every penny that I can because I'm
                 making money as I travel. If you're looking for advice on the
                 cheapest way to do things, this isn't the place for you.
               </p>
@@ -117,7 +117,7 @@ const About = () => {
               </p>
               <p>
                 I find that if I stay in the same place too long, I become
-                obsessed with my routine. My world can become very small, and I
+                obsessed with my routine. My world becomes very small, and I
                 care about things that, once I take a step back and look at them
                 from a distance, I realise are entirely insignificant.
               </p>
@@ -132,35 +132,28 @@ const About = () => {
                 my own world, that I had a spot on the platform, right
                 underneath the air conditioner, that I would stand everyday. If
                 I came into the station and someone was standing in my spot on
-                the platform, it would ruin my day.
-              </p>
-              <p>
-                That's what I mean when I say I would become too obsessed with
-                my routine and would care about insignificant things.
+                the platform, it would ruin my day. That's what I mean when I
+                say I become too obsessed with my routine and care about
+                insignificant things.
               </p>
               <p>
                 So on the one hand, I want to be a nomad so that I'm continually
                 moving around, and I don't have the opportunity for my world to
-                become so small that I care about insignificant things. But on
-                the other hand, backpacking, and moving from hostel to hostel
-                every two or three days, can be just as stressful.
-              </p>
-              <p>
-                At that point, you crave a routine. You dream of being settled
-                down and having a nine-to-five job, and to live in a place that
-                you can call home.
-              </p>
-              <p>
-                My personality matches that lifestyle no more than it matches
-                being settled and doing the same thing everyday.
+                become so small that I care about things that don't matter, but
+                on the other, backpacking, and moving from hostel to hostel
+                every two or three days can be just as stressful. At that point,
+                you crave a routine. You dream of being settled down and having
+                a nine-to-five job, and to live in a place that you can call
+                home. My personality matches that lifestyle no more than it
+                matches being settled and doing the same thing everyday.
               </p>
               <p>
                 Nomadding is my attempt to find the perfect middle-ground.
                 Having weeks or months everywhere I go means that I'm not moving
-                around so much that I long for continuity and routine, but at
-                the same time, I don't stay in each place long enough to
-                build-up such a routine that I start to care about things that
-                really don't matter.
+                around so much that I long for continuity and routine, but that
+                I don't stay in each place long enough to build-up such a
+                routine that I start to care about things that really don't
+                matter.
               </p>
               <p>
                 It is my attempt to find the perfect balance between routine and

--- a/src/pages/articles/index.jsx
+++ b/src/pages/articles/index.jsx
@@ -10,7 +10,7 @@ import { getAllArticles } from '@/lib/getAllArticles'
 import ActivityList from '@/components/ActivityList'
 
 const title =
-  "The good, the bad and the ugly of what I've learned being a nomad"
+  "The good, the bad and the ugly of what I've learned being a digital nomad."
 const description =
   'My thoughts on the best places in the world to sit in a dark room on your computer.'
 
@@ -21,7 +21,7 @@ export default function ArticlesIndex({ articles }) {
         <title>Articles</title>
         <meta name="description" content={`${title} ${description}`} />
       </Head>
-      <SimpleLayout title={title} intro={description}>
+      <SimpleLayout title={title}>
         <ActivityList activities={articles} />
       </SimpleLayout>
     </>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -13,7 +13,7 @@ import { generateRssFeed } from '@/lib/generateRssFeed'
 
 import collateActivity from '@/lib/collateActivity'
 
-const title = 'Software engineer, digital nomad, failed writer.'
+const title = 'Software engineer, digital nomad, insipid writer.'
 const description =
   "I'm Jethro, a nomadic software engineer. I spend my life moving around to some of the most amazing places in the world, then sit in my room coding all day. These are my stories."
 
@@ -77,7 +77,7 @@ const Home = ({ activities }) => {
       <Container className="mt-9">
         <div className="max-w-2xl">
           <h1 className="text-4xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:text-5xl">
-            Software engineer, digital nomad, failed writer.
+            {title}
           </h1>
           <p className="mt-6 text-base text-zinc-600 dark:text-zinc-400">
             {description}

--- a/src/pages/socials.jsx
+++ b/src/pages/socials.jsx
@@ -72,7 +72,8 @@ const Socials = () => {
                 <div className="relative z-10 flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-md shadow-zinc-800/5 ring-1 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
                   <Image
                     src={platform.logo}
-                    alt=""
+                    alt={`${platform.name} logo`}
+                    title=""
                     className="h-8 w-8"
                     unoptimized
                   />


### PR DESCRIPTION
Load all article images on page load (rather than when the user scrolls through them).

This has two advantages:
- The images will _all_ be available to search engine crawlers, rather than just the initial image
- There will be no delay when scrolling images

Also made some insignificant tweaks to some of the site text, adding some missing `alt` text to images, and made some minor layout tweaks.