### PR TITLE
Update timeline styling

### DIFF
--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -28,15 +28,15 @@ const TimelineComponent = ({ timelineData }) => {
 
   return (
     <div className="relative flex flex-col gap-5">
-      <div className="absolute inset-0 flex">
-        <div className="shrink grow basis-1/2 border-r-2 border-zinc-800 dark:border-zinc-100"></div>
-        <div className="shrink grow basis-1/2 border-l-2 border-zinc-800 dark:border-zinc-100"></div>
+      <div className="absolute inset-0 flex border-l-4 border-zinc-800 dark:border-zinc-100 lg:border-l-0">
+        <div className="hidden shrink grow basis-1/2 border-r-2 border-inherit lg:block"></div>
+        <div className="hidden shrink grow basis-1/2 border-l-2 border-inherit lg:block"></div>
       </div>
       {timelineData.map((countryVisit, countryIterator) => {
         return (
           <div
             key={`country-${countryIterator}-section`}
-            className="z-10 rounded-3xl bg-white dark:bg-zinc-900"
+            className="z-10 bg-white dark:bg-zinc-900"
           >
             <h1 className="sticky top-7 z-50 float-left my-8 w-0 translate-x-10 text-xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:whitespace-nowrap sm:text-2xl">
               {countryVisit[country]}
@@ -47,10 +47,10 @@ const TimelineComponent = ({ timelineData }) => {
               return (
                 <div
                   key={`country-${countryIterator}-place-${stayIterator}-section`}
-                  className="flex"
+                  className="lg:flex"
                 >
                   <div
-                    className={`relative shrink grow basis-1/2${
+                    className={`relative hidden shrink grow lg:block basis-1/2${
                       stayOrderFirst ? ' lg:order-last' : ''
                     } order-first`}
                   >
@@ -81,7 +81,7 @@ const TimelineComponent = ({ timelineData }) => {
                     }`}
                   >
                     <div
-                      className={`absolute left-0 border-l-2 dark:border-zinc-100 border-zinc-800${
+                      className={`absolute left-0 border-l-4 dark:border-zinc-100 lg:border-l-2 border-zinc-800${
                         stayOrderFirst
                           ? ' lg:right-0 lg:left-auto lg:border-l-0 lg:border-r-2'
                           : ''
@@ -95,8 +95,8 @@ const TimelineComponent = ({ timelineData }) => {
                       className={`h-5 w-5${
                         stayOrderFirst
                           ? ' lg:order-last lg:translate-x-2.5'
-                          : ''
-                      } order-first shrink-0 grow-0 -translate-x-2.5 rounded-full bg-zinc-800 dark:bg-zinc-100`}
+                          : ' lg:-translate-x-2.5'
+                      } order-first shrink-0 grow-0 -translate-x-2 rounded-full bg-zinc-800 dark:bg-zinc-100`}
                     />
                     <div
                       className={`relative flex h-full flex-col justify-center rounded-3xl bg-zinc-50 p-5 text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur dark:bg-zinc-800 dark:text-zinc-200 dark:ring-white/10 dark:text-zinc-100${

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -76,7 +76,7 @@ const TimelineComponent = ({ timelineData }) => {
                         numberOfNights(stay[arrival], stay[departure]) * 15
                       }px`,
                     }}
-                    className={`relative flex max-h-[150vh] min-h-[106px] shrink grow basis-1/2 items-center justify-start py-1 pr-2 lg:py-1.5 ${
+                    className={`relative flex max-h-[150vh] min-h-[106px] shrink grow basis-1/2 items-center justify-start py-1 pr-2 lg:py-1.5${
                       stayOrderFirst ? ' lg:justify-end lg:pl-2 lg:pr-0' : ''
                     }${stayIterator === 0 ? ' pt-2 lg:pt-3' : ''}${
                       stayIterator === countryVisit.stays.length - 1
@@ -85,10 +85,10 @@ const TimelineComponent = ({ timelineData }) => {
                     }`}
                   >
                     <div
-                      className={`absolute left-0 border-l-4 dark:border-zinc-100 lg:border-l-2 border-zinc-800${
+                      className={`absolute left-0 border-l-4 dark:border-zinc-100 border-zinc-800${
                         stayOrderFirst
                           ? ' lg:right-0 lg:left-auto lg:border-l-0 lg:border-r-2'
-                          : ''
+                          : ' lg:border-l-2'
                       } ${lineClasses(
                         countryIterator,
                         stayIterator,

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -76,7 +76,7 @@ const TimelineComponent = ({ timelineData }) => {
                         numberOfNights(stay[arrival], stay[departure]) * 15
                       }px`,
                     }}
-                    className={`relative flex max-h-[150vh] min-h-[106px] shrink grow basis-1/2 items-center justify-start py-1 pr-2 lg:py-1.5${
+                    className={`relative flex max-h-[1050px] min-h-[106px] shrink grow basis-1/2 items-center justify-start py-1 pr-2 lg:py-1.5${
                       stayOrderFirst ? ' lg:justify-end lg:pl-2 lg:pr-0' : ''
                     }${stayIterator === 0 ? ' pt-2 lg:pt-3' : ''}${
                       stayIterator === countryVisit.stays.length - 1

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -13,6 +13,19 @@ let stayOrderFirst = true
 const TimelineComponent = ({ timelineData }) => {
   const numberOfNights = useNumberOfNights()
 
+  const lineClasses = (countryIterator, stayIterator, stays) => {
+    if (countryIterator === 0 && stayIterator === 0) {
+      return 'after:top-1/2 after:h-1/2'
+    } else if (
+      countryIterator === Object.keys(timelineData).length - 1 &&
+      stayIterator === stays.length - 1
+    ) {
+      return 'after:bottom-1/2 after:h-1/2'
+    } else {
+      return 'after:top-0 after:h-full'
+    }
+  }
+
   return (
     <div className="relative flex flex-col gap-5">
       <div className="absolute inset-0 flex">
@@ -23,7 +36,7 @@ const TimelineComponent = ({ timelineData }) => {
         return (
           <div
             key={`country-${countryIterator}-section`}
-            className="z-10 rounded-3xl"
+            className="z-10 rounded-3xl bg-white dark:bg-zinc-900"
           >
             <h1 className="sticky top-7 z-50 float-left my-8 w-0 translate-x-10 text-xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:whitespace-nowrap sm:text-2xl">
               {countryVisit[country]}
@@ -37,11 +50,15 @@ const TimelineComponent = ({ timelineData }) => {
                   className="flex"
                 >
                   <div
-                    className={`shrink grow basis-1/2${
+                    className={`relative shrink grow basis-1/2${
                       stayOrderFirst
-                        ? ' lg:order-last lg:border-l-2 lg:border-r-0'
+                        ? ' lg:order-last lg:after:left-0 lg:after:right-auto lg:after:border-r-0 lg:after:border-l-2'
                         : ''
-                    } order-first border-r-2 border-zinc-800 dark:border-zinc-100`}
+                    } after:dark:border-zinc-10 order-first after:absolute after:right-0 after:border-r-2 after:border-zinc-800 ${lineClasses(
+                      countryIterator,
+                      stayIterator,
+                      countryVisit.stays
+                    )}`}
                   />
                   <div
                     style={{

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -15,14 +15,14 @@ const TimelineComponent = ({ timelineData }) => {
 
   const lineClasses = (countryIterator, stayIterator, stays) => {
     if (countryIterator === 0 && stayIterator === 0) {
-      return 'after:top-1/2 after:h-1/2'
+      return 'top-1/2 h-1/2'
     } else if (
       countryIterator === Object.keys(timelineData).length - 1 &&
       stayIterator === stays.length - 1
     ) {
-      return 'after:bottom-1/2 after:h-1/2'
+      return 'bottom-1/2 h-1/2'
     } else {
-      return 'after:top-0 after:h-full'
+      return 'top-0 h-full'
     }
   }
 
@@ -51,16 +51,21 @@ const TimelineComponent = ({ timelineData }) => {
                 >
                   <div
                     className={`relative shrink grow basis-1/2${
-                      stayOrderFirst
-                        ? ' lg:order-last lg:after:left-0 lg:after:right-auto lg:after:border-r-0 lg:after:border-l-2'
-                        : ''
-                    } dark:after:border-zinc-10 order-first after:absolute after:right-0 after:border-r-2 after:border-zinc-800 ${lineClasses(
-                      countryIterator,
-                      stayIterator,
-                      countryVisit.stays
-                    )}`}
-                    // dark:after:border-zinc-10 doesn't seem to be working
-                  />
+                      stayOrderFirst ? ' lg:order-last' : ''
+                    } order-first`}
+                  >
+                    <div
+                      className={`absolute right-0 border-r-2 dark:border-zinc-100 border-zinc-800${
+                        stayOrderFirst
+                          ? ' lg:left-0 lg:right-auto lg:border-r-0 lg:border-l-2'
+                          : ''
+                      } ${lineClasses(
+                        countryIterator,
+                        stayIterator,
+                        countryVisit.stays
+                      )}`}
+                    />
+                  </div>
                   <div
                     style={{
                       minHeight: `${Math.max(
@@ -68,20 +73,25 @@ const TimelineComponent = ({ timelineData }) => {
                         96
                       )}px`,
                     }}
-                    className={`dark:after:border-zinc-10 relative flex shrink grow basis-1/2 items-center justify-start py-1 pr-2 after:absolute after:left-0 after:border-l-2 after:border-zinc-800 lg:py-1.5 ${
-                      stayOrderFirst
-                        ? ' lg:justify-end lg:pl-2 lg:pr-0 lg:after:right-0 lg:after:left-auto lg:after:border-l-0 lg:after:border-r-2'
-                        : ''
+                    className={`relative flex shrink grow basis-1/2 items-center justify-start py-1 pr-2 lg:py-1.5 ${
+                      stayOrderFirst ? ' lg:justify-end lg:pl-2 lg:pr-0' : ''
                     }${stayIterator === 0 ? ' pt-2 lg:pt-3' : ''}${
                       stayIterator === countryVisit.stays.length - 1
                         ? ' pb-2 lg:pb-3'
                         : ''
-                    } ${lineClasses(
-                      countryIterator,
-                      stayIterator,
-                      countryVisit.stays
-                    )}`}
+                    }`}
                   >
+                    <div
+                      className={`absolute left-0 border-l-2 dark:border-zinc-100 border-zinc-800${
+                        stayOrderFirst
+                          ? ' lg:right-0 lg:left-auto lg:border-l-0 lg:border-r-2'
+                          : ''
+                      } ${lineClasses(
+                        countryIterator,
+                        stayIterator,
+                        countryVisit.stays
+                      )}`}
+                    />
                     <div
                       className={`h-5 w-5${
                         stayOrderFirst

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -23,9 +23,9 @@ const TimelineComponent = ({ timelineData }) => {
         return (
           <div
             key={`country-${countryIterator}-section`}
-            className="z-10 rounded-3xl bg-zinc-50 dark:bg-zinc-800"
+            className="z-10 rounded-3xl"
           >
-            <h1 className="sticky top-7 float-left my-8 w-0 translate-x-10 text-xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:whitespace-nowrap sm:text-2xl">
+            <h1 className="sticky top-7 z-50 float-left my-8 w-0 translate-x-10 text-xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:whitespace-nowrap sm:text-2xl">
               {countryVisit[country]}
             </h1>
             {countryVisit.stays.map((stay, stayIterator) => {
@@ -66,7 +66,7 @@ const TimelineComponent = ({ timelineData }) => {
                       } order-first shrink-0 grow-0 -translate-x-3 rounded-full bg-zinc-800 dark:bg-zinc-100`}
                     />
                     <div
-                      className={`flex h-full flex-col justify-center rounded-3xl bg-white p-5 text-zinc-800 dark:bg-zinc-900 dark:text-zinc-100${
+                      className={`relative flex h-full flex-col justify-center rounded-3xl bg-zinc-50 p-5 text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur dark:bg-zinc-800 dark:text-zinc-200 dark:ring-white/10 dark:text-zinc-100${
                         stayOrderFirst ? ' lg:text-right' : ''
                       }`}
                     >

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -38,7 +38,11 @@ const TimelineComponent = ({ timelineData }) => {
             key={`country-${countryIterator}-section`}
             className="z-10 bg-white dark:bg-zinc-900"
           >
-            <h1 className="sticky top-7 z-50 float-left my-8 w-0 translate-x-10 text-xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100 sm:whitespace-nowrap sm:text-2xl">
+            <h1
+              className={`border-zinc-800 pl-5 text-xl font-bold tracking-tight text-zinc-800 dark:border-zinc-100 dark:text-zinc-100 sm:text-2xl lg:sticky lg:top-7 lg:z-50 lg:float-left lg:my-8 lg:w-0 lg:translate-x-10 lg:whitespace-nowrap lg:border-l-0 lg:pl-0${
+                countryIterator === 0 ? ' border-l-0' : ' border-l-4'
+              }`}
+            >
               {countryVisit[country]}
             </h1>
             {countryVisit.stays.map((stay, stayIterator) => {

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -37,11 +37,12 @@ const TimelineComponent = ({ timelineData }) => {
                   className="flex"
                 >
                   <div
-                    className={`shrink grow basis-1/2 ${
-                      stayOrderFirst &&
-                      'lg:order-last lg:border-l-2 lg:border-r-0'
+                    className={`shrink grow basis-1/2${
+                      stayOrderFirst
+                        ? ' lg:order-last lg:border-l-2 lg:border-r-0'
+                        : ''
                     } order-first border-r-2 border-zinc-800 dark:border-zinc-100`}
-                  ></div>
+                  />
                   <div
                     style={{
                       minHeight: `${Math.max(
@@ -49,19 +50,24 @@ const TimelineComponent = ({ timelineData }) => {
                         96
                       )}px`,
                     }}
-                    className={`flex shrink grow basis-1/2 items-center justify-start border-l-2 border-zinc-800 pr-2 dark:border-zinc-100 ${
-                      stayOrderFirst &&
-                      'lg:justify-end lg:border-r-2 lg:border-l-0 lg:pl-2 lg:pr-0'
+                    className={`flex shrink grow basis-1/2 items-center justify-start border-l-2 border-zinc-800 py-1 pr-2 lg:py-1.5 dark:border-zinc-100${
+                      stayOrderFirst
+                        ? ' lg:justify-end lg:border-r-2 lg:border-l-0 lg:pl-2 lg:pr-0'
+                        : ''
+                    }${stayIterator === 0 ? ' pt-2 lg:pt-3' : ''}${
+                      stayIterator === countryVisit.stays.length - 1
+                        ? ' pb-2 lg:pb-3'
+                        : ''
                     }`}
                   >
                     <div
-                      className={`h-5 w-5 ${
-                        stayOrderFirst && 'lg:order-last lg:translate-x-3'
+                      className={`h-5 w-5${
+                        stayOrderFirst ? ' lg:order-last lg:translate-x-3' : ''
                       } order-first shrink-0 grow-0 -translate-x-3 rounded-full bg-zinc-800 dark:bg-zinc-100`}
-                    ></div>
+                    />
                     <div
-                      className={`flex flex-col text-zinc-800 dark:text-zinc-100 ${
-                        stayOrderFirst && 'lg:text-right'
+                      className={`flex h-full flex-col justify-center rounded-3xl bg-white p-5 text-zinc-800 dark:bg-zinc-900 dark:text-zinc-100${
+                        stayOrderFirst ? ' lg:text-right' : ''
                       }`}
                     >
                       <div className="font-bold">{stay[place]}</div>

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -68,12 +68,11 @@ const TimelineComponent = ({ timelineData }) => {
                   </div>
                   <div
                     style={{
-                      minHeight: `${Math.max(
-                        numberOfNights(stay[arrival], stay[departure]) * 15,
-                        96
-                      )}px`,
+                      height: `${
+                        numberOfNights(stay[arrival], stay[departure]) * 15
+                      }px`,
                     }}
-                    className={`relative flex shrink grow basis-1/2 items-center justify-start py-1 pr-2 lg:py-1.5 ${
+                    className={`relative flex max-h-[150vh] min-h-[106px] shrink grow basis-1/2 items-center justify-start py-1 pr-2 lg:py-1.5 ${
                       stayOrderFirst ? ' lg:justify-end lg:pl-2 lg:pr-0' : ''
                     }${stayIterator === 0 ? ' pt-2 lg:pt-3' : ''}${
                       stayIterator === countryVisit.stays.length - 1

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -54,11 +54,12 @@ const TimelineComponent = ({ timelineData }) => {
                       stayOrderFirst
                         ? ' lg:order-last lg:after:left-0 lg:after:right-auto lg:after:border-r-0 lg:after:border-l-2'
                         : ''
-                    } after:dark:border-zinc-10 order-first after:absolute after:right-0 after:border-r-2 after:border-zinc-800 ${lineClasses(
+                    } dark:after:border-zinc-10 order-first after:absolute after:right-0 after:border-r-2 after:border-zinc-800 ${lineClasses(
                       countryIterator,
                       stayIterator,
                       countryVisit.stays
                     )}`}
+                    // dark:after:border-zinc-10 doesn't seem to be working
                   />
                   <div
                     style={{
@@ -67,20 +68,26 @@ const TimelineComponent = ({ timelineData }) => {
                         96
                       )}px`,
                     }}
-                    className={`flex shrink grow basis-1/2 items-center justify-start border-l-2 border-zinc-800 py-1 pr-2 lg:py-1.5 dark:border-zinc-100${
+                    className={`dark:after:border-zinc-10 relative flex shrink grow basis-1/2 items-center justify-start py-1 pr-2 after:absolute after:left-0 after:border-l-2 after:border-zinc-800 lg:py-1.5 ${
                       stayOrderFirst
-                        ? ' lg:justify-end lg:border-r-2 lg:border-l-0 lg:pl-2 lg:pr-0'
+                        ? ' lg:justify-end lg:pl-2 lg:pr-0 lg:after:right-0 lg:after:left-auto lg:after:border-l-0 lg:after:border-r-2'
                         : ''
                     }${stayIterator === 0 ? ' pt-2 lg:pt-3' : ''}${
                       stayIterator === countryVisit.stays.length - 1
                         ? ' pb-2 lg:pb-3'
                         : ''
-                    }`}
+                    } ${lineClasses(
+                      countryIterator,
+                      stayIterator,
+                      countryVisit.stays
+                    )}`}
                   >
                     <div
                       className={`h-5 w-5${
-                        stayOrderFirst ? ' lg:order-last lg:translate-x-3' : ''
-                      } order-first shrink-0 grow-0 -translate-x-3 rounded-full bg-zinc-800 dark:bg-zinc-100`}
+                        stayOrderFirst
+                          ? ' lg:order-last lg:translate-x-2.5'
+                          : ''
+                      } order-first shrink-0 grow-0 -translate-x-2.5 rounded-full bg-zinc-800 dark:bg-zinc-100`}
                     />
                     <div
                       className={`relative flex h-full flex-col justify-center rounded-3xl bg-zinc-50 p-5 text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur dark:bg-zinc-800 dark:text-zinc-200 dark:ring-white/10 dark:text-zinc-100${

--- a/src/pages/timeline.jsx
+++ b/src/pages/timeline.jsx
@@ -8,11 +8,8 @@
 // - Not sure this would work on mobile, so one option is to move the timeline to the very left edge of the screen on mobile (so that you can only see half of the bullet). Photos could then be underneath the stay details.
 // TODO: Add Google Maps links to some or all stays?
 // TODO: Add description to some or all stays?
-// FIXME: The top timeline element bullet should not have a vertical line coming out the top, and the bottom bullet should not have a line coming out the bottom
 // TODO: Add the accommodation type somehow - feasibly using a logo in the bullet, such as a camping logo or an Airbnb logo
 // TODO: There should be more empty space between stays (and countries) if there's a blank day or two between them
-// TODO: Give each 'stay' element a max-height; perhaps 120vh (currently long stays take multiple times the height of the viewport and looks/feels a bit ridiculous)
-// - Consider shortening this for 'top' (latest) stays, or moving the bullet to the top, because if there's no line from the top bullet and the stay isn't even on the screen, it'll look a bit ridiculous.
 
 import { useState } from 'react'
 

--- a/src/pages/timeline.jsx
+++ b/src/pages/timeline.jsx
@@ -8,9 +8,6 @@
 // - Not sure this would work on mobile, so one option is to move the timeline to the very left edge of the screen on mobile (so that you can only see half of the bullet). Photos could then be underneath the stay details.
 // TODO: Add Google Maps links to some or all stays?
 // TODO: Add description to some or all stays?
-// TODO: Make clearer the length of each stay
-// - Currently a short stay looks much longer than it is if it's surrounded by longer stays. Make it more obvious how long a stay is by highlighting each stay somehow.
-// - Changing the background colour of each stay is one option
 // FIXME: The top timeline element bullet should not have a vertical line coming out the top, and the bottom bullet should not have a line coming out the bottom
 // TODO: Add the accommodation type somehow - feasibly using a logo in the bullet, such as a camping logo or an Airbnb logo
 // TODO: There should be more empty space between stays (and countries) if there's a blank day or two between them

--- a/src/pages/timeline.jsx
+++ b/src/pages/timeline.jsx
@@ -65,7 +65,7 @@ const timelineDates = {
 const introText = {
   [digitalNomad]: 'Where being a digital nomad has taken me.',
   [backpackingTrip]:
-    'Before I was a digital nomad, I went on a backpacking trip that started with being a lifty in Canada in 2008, led to six years as an English teacher in Thailand and China, and finished with doing the coding bootcamp in Bali that paved the way for me to become a software engineer, and ultimately a digital nomad.',
+    'Before I was a digital nomad, I went on a backpacking trip that started with being a lifty in Canada in 2008, led to six years as an English teacher in Thailand and China, and finished with doing a coding bootcamp in Bali in 2018 that paved the way for me to become a software engineer, and ultimately a digital nomad.',
   [mexico08]: 'A university reunion in Mexico.',
   [dalhousie]:
     'A university exchange to Dalhouse University in Nova Scotia with some time to travel over the Christmas break.',


### PR DESCRIPTION
A big update to the appearance of the timeline.

## Before

<img width="1512" alt="Screenshot 2023-09-02 at 19 51 50" src="https://github.com/jro31/slowmadding/assets/35604636/a655fe63-3948-4ff1-8079-cdc0efbe7667">

<img width="1512" alt="Screenshot 2023-09-02 at 19 51 44" src="https://github.com/jro31/slowmadding/assets/35604636/ce405192-cd16-4e10-afca-5f3ab9f45561">

<img width="371" alt="Screenshot 2023-09-02 at 19 52 15" src="https://github.com/jro31/slowmadding/assets/35604636/137b941d-e352-4056-9d50-acf166477b70">

<img width="368" alt="Screenshot 2023-09-02 at 19 52 29" src="https://github.com/jro31/slowmadding/assets/35604636/d068b2be-a9ef-452f-80f9-8641e122aedb">

## After

<img width="1512" alt="Screenshot 2023-09-02 at 19 51 29" src="https://github.com/jro31/slowmadding/assets/35604636/230f616b-b96e-4f5f-bbf0-1bd7088648ce">

<img width="1512" alt="Screenshot 2023-09-02 at 19 51 35" src="https://github.com/jro31/slowmadding/assets/35604636/7e213d6d-2cf8-40b7-9a0a-7a2a46c24c22">

<img width="372" alt="Screenshot 2023-09-02 at 19 51 17" src="https://github.com/jro31/slowmadding/assets/35604636/e85384e8-1aa9-4269-99f5-31eb8ca15e77">

<img width="369" alt="Screenshot 2023-09-02 at 19 50 57" src="https://github.com/jro31/slowmadding/assets/35604636/c89d8024-6c7f-4f5d-9e04-9547c70a4577">
