### PR TITLE
Fix timeline bug

### DIFF
--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -48,6 +48,11 @@ const TimelineComponent = ({ timelineData }) => {
             {countryVisit.stays.map((stay, stayIterator) => {
               stayOrderFirst = !stayOrderFirst
 
+              const parsedDepartureDate =
+                Date.parse(stay[departure]) >= Date.parse(new Date())
+                  ? new Date().toJSON().slice(0, 10)
+                  : stay[departure]
+
               return (
                 <div
                   key={`country-${countryIterator}-place-${stayIterator}-section`}
@@ -73,7 +78,7 @@ const TimelineComponent = ({ timelineData }) => {
                   <div
                     style={{
                       height: `${
-                        numberOfNights(stay[arrival], stay[departure]) * 15
+                        numberOfNights(stay[arrival], parsedDepartureDate) * 15
                       }px`,
                     }}
                     className={`relative flex max-h-[1050px] min-h-[106px] shrink grow basis-1/2 items-center justify-start py-1 pr-2 lg:py-1.5${
@@ -109,7 +114,7 @@ const TimelineComponent = ({ timelineData }) => {
                     >
                       <div className="font-bold">{stay[place]}</div>
                       <div>
-                        {formatDateRange(stay[arrival], stay[departure])}
+                        {formatDateRange(stay[arrival], parsedDepartureDate)}
                       </div>
                     </div>
                   </div>

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -6,7 +6,7 @@ import {
   country,
   place,
 } from '@/lib/timelineData/variables'
-import { formatDateRange } from '@/lib/formatDate'
+import { formatDateRange, beginningOfToday } from '@/lib/formatDate'
 
 let stayOrderFirst = true
 
@@ -25,6 +25,12 @@ const TimelineComponent = ({ timelineData }) => {
       return 'top-0 h-full'
     }
   }
+
+  timelineData = timelineData.filter((countryVisit) =>
+    countryVisit.stays.some(
+      (stay) => Date.parse(stay[arrival]) < beginningOfToday
+    )
+  )
 
   return (
     <div className="relative flex flex-col gap-5">
@@ -46,80 +52,83 @@ const TimelineComponent = ({ timelineData }) => {
               {countryVisit[country]}
             </h1>
             {countryVisit.stays.map((stay, stayIterator) => {
-              stayOrderFirst = !stayOrderFirst
+              if (Date.parse(stay[arrival]) < beginningOfToday) {
+                stayOrderFirst = !stayOrderFirst
 
-              const parsedDepartureDate =
-                Date.parse(stay[departure]) >= Date.parse(new Date())
-                  ? new Date().toJSON().slice(0, 10)
-                  : stay[departure]
+                const parsedDepartureDate =
+                  Date.parse(stay[departure]) >= beginningOfToday
+                    ? beginningOfToday
+                    : stay[departure]
 
-              return (
-                <div
-                  key={`country-${countryIterator}-place-${stayIterator}-section`}
-                  className="lg:flex"
-                >
+                return (
                   <div
-                    className={`relative hidden shrink grow lg:block basis-1/2${
-                      stayOrderFirst ? ' lg:order-last' : ''
-                    } order-first`}
+                    key={`country-${countryIterator}-place-${stayIterator}-section`}
+                    className="lg:flex"
                   >
                     <div
-                      className={`absolute right-0 border-r-2 dark:border-zinc-100 border-zinc-800${
-                        stayOrderFirst
-                          ? ' lg:left-0 lg:right-auto lg:border-r-0 lg:border-l-2'
+                      className={`relative hidden shrink grow lg:block basis-1/2${
+                        stayOrderFirst ? ' lg:order-last' : ''
+                      } order-first`}
+                    >
+                      <div
+                        className={`absolute right-0 border-r-2 dark:border-zinc-100 border-zinc-800${
+                          stayOrderFirst
+                            ? ' lg:left-0 lg:right-auto lg:border-r-0 lg:border-l-2'
+                            : ''
+                        } ${lineClasses(
+                          countryIterator,
+                          stayIterator,
+                          countryVisit.stays
+                        )}`}
+                      />
+                    </div>
+                    <div
+                      style={{
+                        height: `${
+                          numberOfNights(stay[arrival], parsedDepartureDate) *
+                          15
+                        }px`,
+                      }}
+                      className={`relative flex max-h-[1050px] min-h-[106px] shrink grow basis-1/2 items-center justify-start py-1 pr-2 lg:py-1.5${
+                        stayOrderFirst ? ' lg:justify-end lg:pl-2 lg:pr-0' : ''
+                      }${stayIterator === 0 ? ' pt-2 lg:pt-3' : ''}${
+                        stayIterator === countryVisit.stays.length - 1
+                          ? ' pb-2 lg:pb-3'
                           : ''
-                      } ${lineClasses(
-                        countryIterator,
-                        stayIterator,
-                        countryVisit.stays
-                      )}`}
-                    />
-                  </div>
-                  <div
-                    style={{
-                      height: `${
-                        numberOfNights(stay[arrival], parsedDepartureDate) * 15
-                      }px`,
-                    }}
-                    className={`relative flex max-h-[1050px] min-h-[106px] shrink grow basis-1/2 items-center justify-start py-1 pr-2 lg:py-1.5${
-                      stayOrderFirst ? ' lg:justify-end lg:pl-2 lg:pr-0' : ''
-                    }${stayIterator === 0 ? ' pt-2 lg:pt-3' : ''}${
-                      stayIterator === countryVisit.stays.length - 1
-                        ? ' pb-2 lg:pb-3'
-                        : ''
-                    }`}
-                  >
-                    <div
-                      className={`absolute left-0 border-l-4 dark:border-zinc-100 border-zinc-800${
-                        stayOrderFirst
-                          ? ' lg:right-0 lg:left-auto lg:border-l-0 lg:border-r-2'
-                          : ' lg:border-l-2'
-                      } ${lineClasses(
-                        countryIterator,
-                        stayIterator,
-                        countryVisit.stays
-                      )}`}
-                    />
-                    <div
-                      className={`h-5 w-5${
-                        stayOrderFirst
-                          ? ' lg:order-last lg:translate-x-2.5'
-                          : ' lg:-translate-x-2.5'
-                      } order-first shrink-0 grow-0 -translate-x-2 rounded-full bg-zinc-800 dark:bg-zinc-100`}
-                    />
-                    <div
-                      className={`relative flex h-full flex-col justify-center rounded-3xl bg-zinc-50 p-5 text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur dark:bg-zinc-800 dark:text-zinc-200 dark:ring-white/10 dark:text-zinc-100${
-                        stayOrderFirst ? ' lg:text-right' : ''
                       }`}
                     >
-                      <div className="font-bold">{stay[place]}</div>
-                      <div>
-                        {formatDateRange(stay[arrival], parsedDepartureDate)}
+                      <div
+                        className={`absolute left-0 border-l-4 dark:border-zinc-100 border-zinc-800${
+                          stayOrderFirst
+                            ? ' lg:right-0 lg:left-auto lg:border-l-0 lg:border-r-2'
+                            : ' lg:border-l-2'
+                        } ${lineClasses(
+                          countryIterator,
+                          stayIterator,
+                          countryVisit.stays
+                        )}`}
+                      />
+                      <div
+                        className={`h-5 w-5${
+                          stayOrderFirst
+                            ? ' lg:order-last lg:translate-x-2.5'
+                            : ' lg:-translate-x-2.5'
+                        } order-first shrink-0 grow-0 -translate-x-2 rounded-full bg-zinc-800 dark:bg-zinc-100`}
+                      />
+                      <div
+                        className={`relative flex h-full flex-col justify-center rounded-3xl bg-zinc-50 p-5 text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur dark:bg-zinc-800 dark:text-zinc-200 dark:ring-white/10 dark:text-zinc-100${
+                          stayOrderFirst ? ' lg:text-right' : ''
+                        }`}
+                      >
+                        <div className="font-bold">{stay[place]}</div>
+                        <div>
+                          {formatDateRange(stay[arrival], parsedDepartureDate)}
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              )
+                )
+              }
             })}
           </div>
         )

--- a/src/lib/formatDate.js
+++ b/src/lib/formatDate.js
@@ -1,5 +1,7 @@
 let formattedDate
 
+export const beginningOfToday = Date.parse(new Date().toJSON().slice(0, 10))
+
 const suffix = (day) => {
   const suffixes = ['st', 'nd', 'rd', 'th']
 

--- a/src/lib/timelineData/index.js
+++ b/src/lib/timelineData/index.js
@@ -67,10 +67,7 @@ const orderedTimelineArray = (startDate, endDate) => {
               Date.parse(startDate) > Date.parse(stay[dates][arrival])
                 ? startDate
                 : stay[dates][arrival],
-            [departure]:
-              Date.parse(endDate) < Date.parse(stay[dates][departure])
-                ? endDate
-                : stay[dates][departure],
+            [departure]: stay[dates][departure],
           })
         }
       })

--- a/src/lib/timelineData/index.js
+++ b/src/lib/timelineData/index.js
@@ -1,6 +1,7 @@
 import { countries } from '@/lib/placeNames'
 
 import { dates, arrival, departure, country, place } from './variables'
+import { beginningOfToday } from '../formatDate'
 
 import { argentinaData } from './argentinaData'
 import { boliviaData } from './boliviaData'
@@ -50,16 +51,22 @@ const timelineData = {
   [countries.vietnam]: vietnamData,
 }
 
+let endDateIsSet = true
+
 const orderedTimelineArray = (startDate, endDate) => {
   let returnArray = []
+
+  const stayIsInDateRange = (stay) =>
+    Date.parse(stay[dates][departure]) >= Date.parse(startDate) &&
+    Date.parse(stay[dates][arrival]) < Date.parse(endDate)
+
+  const stayIsFuture = (stay) =>
+    Date.parse(stay[dates][arrival]) >= beginningOfToday
 
   Object.keys(timelineData).map((countryKey) => {
     Object.keys(timelineData[countryKey]).map((placeKey) => {
       timelineData[countryKey][placeKey].map((stay) => {
-        if (
-          Date.parse(stay[dates][departure]) >= Date.parse(startDate) &&
-          Date.parse(stay[dates][arrival]) < Date.parse(endDate)
-        ) {
+        if (stayIsInDateRange(stay) || (!endDateIsSet && stayIsFuture(stay))) {
           returnArray.push({
             [country]: countryKey,
             [place]: placeKey,
@@ -105,10 +112,14 @@ const stayObject = (stay) => ({
 })
 
 // TODO: Add any more checks to validate the date, such as the arrival date must be before the departure date
-export const parsedTimelineData = (
-  startDate,
-  endDate = new Date().toJSON().slice(0, 10)
-) => {
+export const parsedTimelineData = (startDate, endDate) => {
+  if (endDate) {
+    endDateIsSet = true
+  } else {
+    endDateIsSet = false
+    endDate = new Date().toJSON().slice(0, 10)
+  }
+
   let returnArray = []
   orderedTimelineArray(startDate, endDate).map((stay, iterator) => {
     if (

--- a/src/pages/timeline.jsx
+++ b/src/pages/timeline.jsx
@@ -36,7 +36,7 @@ const endDate = 'End date'
 const timelineDates = {
   [digitalNomad]: {
     [startDate]: '2022-10-07',
-    [endDate]: undefined,
+    [endDate]: null,
   },
   [backpackingTrip]: {
     [startDate]: '2008-11-20',


### PR DESCRIPTION
This PR fixes a bug in the timeline where the timeline data was being parsed at build-time (in `getStaticProps`), which meant that if I had a stay that was, for example, on the 1st to the 5th, and I build the app on the 2nd, then if I accessed the app on the 3rd, the stay would still be 1st to 2nd.

I wanted to continue parsing the data at build-time, because it's quite a lot of data to work through and doing it client-side would slow-down the app, so this PR updates the data that's returned, and updates how it's processed client-side to display it as wanted.