### PR TITLE
Fix timeline time zone bug

### DIFF
--- a/src/components/AccommodationTable/Dates.jsx
+++ b/src/components/AccommodationTable/Dates.jsx
@@ -12,7 +12,8 @@ const Dates = ({ dates }) => {
   const contentString = () => {
     return `<div>${formatDateRange(
       checkIn,
-      checkOut
+      checkOut,
+      'UTC'
     )}</div><div>${numberOfNightsString()}</div>`
   }
 

--- a/src/components/AccommodationTable/Dates.jsx
+++ b/src/components/AccommodationTable/Dates.jsx
@@ -12,8 +12,7 @@ const Dates = ({ dates }) => {
   const contentString = () => {
     return `<div>${formatDateRange(
       checkIn,
-      checkOut,
-      'UTC'
+      checkOut
     )}</div><div>${numberOfNightsString()}</div>`
   }
 

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -6,7 +6,7 @@ import {
   country,
   place,
 } from '@/lib/timelineData/variables'
-import { formatDateRange, beginningOfToday } from '@/lib/formatDate'
+import { formatDateRange, usersDate } from '@/lib/formatDate'
 
 let stayOrderFirst = true
 
@@ -29,9 +29,7 @@ const TimelineComponent = ({ timelineData, ascending, compactMode }) => {
   const orderedArray = (array) => (ascending ? [...array].reverse() : array)
 
   timelineData = timelineData.filter((countryVisit) =>
-    countryVisit.stays.some(
-      (stay) => Date.parse(stay[arrival]) < beginningOfToday
-    )
+    countryVisit.stays.some((stay) => stay[arrival] < usersDate)
   )
 
   return (
@@ -54,16 +52,14 @@ const TimelineComponent = ({ timelineData, ascending, compactMode }) => {
               {countryVisit[country]}
             </h1>
             {orderedArray(countryVisit.stays).map((stay, stayIterator) => {
-              if (Date.parse(stay[arrival]) < beginningOfToday) {
+              if (stay[arrival] < usersDate) {
                 stayOrderFirst =
                   countryIterator === 0 && stayIterator === 0
                     ? true
                     : !stayOrderFirst
 
-                const parsedDepartureDate =
-                  Date.parse(stay[departure]) >= beginningOfToday
-                    ? beginningOfToday
-                    : stay[departure]
+                const adjustedDepartureDate =
+                  stay[departure] > usersDate ? usersDate : stay[departure]
 
                 return (
                   <div
@@ -96,7 +92,7 @@ const TimelineComponent = ({ timelineData, ascending, compactMode }) => {
                                 Math.max(
                                   numberOfNights(
                                     stay[arrival],
-                                    parsedDepartureDate
+                                    adjustedDepartureDate
                                   ) * 15,
                                   106
                                 ),
@@ -139,8 +135,7 @@ const TimelineComponent = ({ timelineData, ascending, compactMode }) => {
                         <div>
                           {formatDateRange(
                             stay[arrival],
-                            parsedDepartureDate,
-                            'UTC'
+                            adjustedDepartureDate
                           )}
                         </div>
                       </div>

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -29,7 +29,9 @@ const TimelineComponent = ({ timelineData, ascending, compactMode }) => {
   const orderedArray = (array) => (ascending ? [...array].reverse() : array)
 
   timelineData = timelineData.filter((countryVisit) =>
-    countryVisit.stays.some((stay) => stay[arrival] < usersDate)
+    countryVisit.stays.some(
+      (stay) => new Date(stay[arrival]) < new Date(usersDate)
+    )
   )
 
   return (
@@ -52,14 +54,16 @@ const TimelineComponent = ({ timelineData, ascending, compactMode }) => {
               {countryVisit[country]}
             </h1>
             {orderedArray(countryVisit.stays).map((stay, stayIterator) => {
-              if (stay[arrival] < usersDate) {
+              if (new Date(stay[arrival]) < new Date(usersDate)) {
                 stayOrderFirst =
                   countryIterator === 0 && stayIterator === 0
                     ? true
                     : !stayOrderFirst
 
                 const adjustedDepartureDate =
-                  stay[departure] > usersDate ? usersDate : stay[departure]
+                  new Date(stay[departure]) > new Date(usersDate)
+                    ? usersDate
+                    : stay[departure]
 
                 return (
                   <div

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -8,9 +8,8 @@ import {
 } from '@/lib/timelineData/variables'
 import { formatDateRange, usersDate } from '@/lib/formatDate'
 
-let stayOrderFirst = true
-
 const TimelineComponent = ({ timelineData, ascending, compactMode }) => {
+  let stayOrderFirst = true
   const numberOfNights = useNumberOfNights()
 
   const lineClasses = (countryIterator, stayIterator, stays) => {
@@ -28,11 +27,25 @@ const TimelineComponent = ({ timelineData, ascending, compactMode }) => {
 
   const orderedArray = (array) => (ascending ? [...array].reverse() : array)
 
-  timelineData = timelineData.filter((countryVisit) =>
-    countryVisit.stays.some(
-      (stay) => new Date(stay[arrival]) < new Date(usersDate)
-    )
-  )
+  const removeFutureCountries = () =>
+    (timelineData = timelineData.filter((countryVisit) =>
+      countryVisit.stays.some(
+        (stay) => new Date(stay[arrival]) < new Date(usersDate)
+      )
+    ))
+
+  const removeFutureStays = () =>
+    (timelineData = timelineData.map((countryVisit) => {
+      return {
+        ...countryVisit,
+        stays: countryVisit.stays.filter(
+          (stay) => new Date(stay[arrival]) < new Date(usersDate)
+        ),
+      }
+    }))
+
+  removeFutureCountries()
+  removeFutureStays()
 
   return (
     <div className="relative flex flex-col gap-5">
@@ -54,99 +67,94 @@ const TimelineComponent = ({ timelineData, ascending, compactMode }) => {
               {countryVisit[country]}
             </h1>
             {orderedArray(countryVisit.stays).map((stay, stayIterator) => {
-              if (new Date(stay[arrival]) < new Date(usersDate)) {
-                stayOrderFirst =
-                  countryIterator === 0 && stayIterator === 0
-                    ? true
-                    : !stayOrderFirst
+              stayOrderFirst =
+                countryIterator === 0 && stayIterator === 0
+                  ? true
+                  : !stayOrderFirst
 
-                const adjustedDepartureDate =
-                  new Date(stay[departure]) > new Date(usersDate)
-                    ? usersDate
-                    : stay[departure]
+              const adjustedDepartureDate =
+                new Date(stay[departure]) > new Date(usersDate)
+                  ? usersDate
+                  : stay[departure]
 
-                return (
+              return (
+                <div
+                  key={`country-${countryIterator}-place-${stayIterator}-section`}
+                  className="flex"
+                >
                   <div
-                    key={`country-${countryIterator}-place-${stayIterator}-section`}
-                    className="flex"
+                    className={`relative hidden shrink grow lg:block basis-1/2${
+                      stayOrderFirst ? ' lg:order-last' : ''
+                    } order-first`}
                   >
                     <div
-                      className={`relative hidden shrink grow lg:block basis-1/2${
-                        stayOrderFirst ? ' lg:order-last' : ''
-                      } order-first`}
-                    >
-                      <div
-                        className={`absolute right-0 border-r-2 dark:border-zinc-100 border-zinc-800${
-                          stayOrderFirst
-                            ? ' lg:left-0 lg:right-auto lg:border-r-0 lg:border-l-2'
-                            : ''
-                        } ${lineClasses(
-                          countryIterator,
-                          stayIterator,
-                          countryVisit.stays
-                        )}`}
-                      />
-                    </div>
-                    <div
-                      style={
-                        compactMode
-                          ? { minHeight: '106px' }
-                          : {
-                              minHeight: `${Math.min(
-                                Math.max(
-                                  numberOfNights(
-                                    stay[arrival],
-                                    adjustedDepartureDate
-                                  ) * 15,
-                                  106
-                                ),
-                                1050
-                              )}px`,
-                            }
-                      }
-                      className={`relative flex max-h-[1050px] shrink grow basis-1/2 items-center justify-start py-1 pr-2 transition-[min-height] duration-700 lg:py-1.5${
-                        stayOrderFirst ? ' lg:justify-end lg:pl-2 lg:pr-0' : ''
-                      }${stayIterator === 0 ? ' pt-2 lg:pt-3' : ''}${
-                        stayIterator === countryVisit.stays.length - 1
-                          ? ' pb-2 lg:pb-3'
+                      className={`absolute right-0 border-r-2 dark:border-zinc-100 border-zinc-800${
+                        stayOrderFirst
+                          ? ' lg:left-0 lg:right-auto lg:border-r-0 lg:border-l-2'
                           : ''
+                      } ${lineClasses(
+                        countryIterator,
+                        stayIterator,
+                        countryVisit.stays
+                      )}`}
+                    />
+                  </div>
+                  <div
+                    style={
+                      compactMode
+                        ? { minHeight: '106px' }
+                        : {
+                            minHeight: `${Math.min(
+                              Math.max(
+                                numberOfNights(
+                                  stay[arrival],
+                                  adjustedDepartureDate
+                                ) * 15,
+                                106
+                              ),
+                              1050
+                            )}px`,
+                          }
+                    }
+                    className={`relative flex max-h-[1050px] shrink grow basis-1/2 items-center justify-start py-1 pr-2 transition-[min-height] duration-700 lg:py-1.5${
+                      stayOrderFirst ? ' lg:justify-end lg:pl-2 lg:pr-0' : ''
+                    }${stayIterator === 0 ? ' pt-2 lg:pt-3' : ''}${
+                      stayIterator === countryVisit.stays.length - 1
+                        ? ' pb-2 lg:pb-3'
+                        : ''
+                    }`}
+                  >
+                    <div
+                      className={`absolute left-0 border-l-4 dark:border-zinc-100 border-zinc-800${
+                        stayOrderFirst
+                          ? ' lg:right-0 lg:left-auto lg:border-l-0 lg:border-r-2'
+                          : ' lg:border-l-2'
+                      } ${lineClasses(
+                        countryIterator,
+                        stayIterator,
+                        countryVisit.stays
+                      )}`}
+                    />
+                    <div
+                      className={`h-5 w-5${
+                        stayOrderFirst
+                          ? ' lg:order-last lg:translate-x-2.5'
+                          : ' lg:-translate-x-2.5'
+                      } order-first shrink-0 grow-0 -translate-x-2 rounded-full bg-zinc-800 dark:bg-zinc-100`}
+                    />
+                    <div
+                      className={`relative flex h-full flex-col justify-center rounded-3xl bg-zinc-50 p-5 text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur dark:bg-zinc-800 dark:text-zinc-200 dark:ring-white/10 dark:text-zinc-100${
+                        stayOrderFirst ? ' lg:text-right' : ''
                       }`}
                     >
-                      <div
-                        className={`absolute left-0 border-l-4 dark:border-zinc-100 border-zinc-800${
-                          stayOrderFirst
-                            ? ' lg:right-0 lg:left-auto lg:border-l-0 lg:border-r-2'
-                            : ' lg:border-l-2'
-                        } ${lineClasses(
-                          countryIterator,
-                          stayIterator,
-                          countryVisit.stays
-                        )}`}
-                      />
-                      <div
-                        className={`h-5 w-5${
-                          stayOrderFirst
-                            ? ' lg:order-last lg:translate-x-2.5'
-                            : ' lg:-translate-x-2.5'
-                        } order-first shrink-0 grow-0 -translate-x-2 rounded-full bg-zinc-800 dark:bg-zinc-100`}
-                      />
-                      <div
-                        className={`relative flex h-full flex-col justify-center rounded-3xl bg-zinc-50 p-5 text-zinc-800 shadow-lg shadow-zinc-800/5 ring-1 ring-zinc-900/5 backdrop-blur dark:bg-zinc-800 dark:text-zinc-200 dark:ring-white/10 dark:text-zinc-100${
-                          stayOrderFirst ? ' lg:text-right' : ''
-                        }`}
-                      >
-                        <div className="font-bold">{stay[place]}</div>
-                        <div>
-                          {formatDateRange(
-                            stay[arrival],
-                            adjustedDepartureDate
-                          )}
-                        </div>
+                      <div className="font-bold">{stay[place]}</div>
+                      <div>
+                        {formatDateRange(stay[arrival], adjustedDepartureDate)}
                       </div>
                     </div>
                   </div>
-                )
-              }
+                </div>
+              )
             })}
           </div>
         )

--- a/src/components/TimelineComponent.jsx
+++ b/src/components/TimelineComponent.jsx
@@ -137,7 +137,11 @@ const TimelineComponent = ({ timelineData, ascending, compactMode }) => {
                       >
                         <div className="font-bold">{stay[place]}</div>
                         <div>
-                          {formatDateRange(stay[arrival], parsedDepartureDate)}
+                          {formatDateRange(
+                            stay[arrival],
+                            parsedDepartureDate,
+                            'UTC'
+                          )}
                         </div>
                       </div>
                     </div>

--- a/src/lib/formatDate.js
+++ b/src/lib/formatDate.js
@@ -1,6 +1,16 @@
 let formattedDate
 
-export const beginningOfToday = Date.parse(new Date().toJSON().slice(0, 10))
+// '2023-11-01'
+const parsedDateAsString = (parsedDate) =>
+  new Date(parsedDate).toISOString().split('T')[0]
+
+// 2023-11-01T17:58:49.084Z
+const usersDateTime = (UTCDatetime = new Date()) =>
+  new Date(
+    new Date(UTCDatetime).getTime() + -new Date().getTimezoneOffset() * 60000
+  )
+
+export const usersDate = parsedDateAsString(usersDateTime())
 
 const suffix = (day) => {
   const suffixes = ['st', 'nd', 'rd', 'th']
@@ -19,16 +29,12 @@ const addOrdinal = () => {
   formattedDate = formattedDate.replace(dayAsString, suffixedDay)
 }
 
-export const formatDate = (
-  dateString,
-  includeOrdinal = false,
-  timezone = null
-) => {
+export const formatDate = (dateString, includeOrdinal = false) => {
   formattedDate = new Date(dateString).toLocaleDateString('en-GB', {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
-    ...(timezone && { timezone: timezone }),
+    timeZone: 'UTC',
   })
 
   if (includeOrdinal) addOrdinal()
@@ -36,26 +42,23 @@ export const formatDate = (
   return formattedDate
 }
 
-const dateIsToday = (dateString) =>
-  formatDate(dateString) === formatDate(new Date())
+const formattedDateYear = (formattedDate) =>
+  formattedDate.split(' ').slice(-1)[0]
+
+const dateStringIsToday = (dateString) => usersDate === dateString
 
 export const formatDateRange = (
   startDateString,
   endDateString,
-  includeOrdinals = true,
-  timezone = null
+  includeOrdinals = true
 ) => {
-  let formattedStartDate = formatDate(
-    startDateString,
-    includeOrdinals,
-    timezone
-  )
-  const formattedEndDate = formatDate(endDateString, includeOrdinals, timezone)
+  let formattedStartDate = formatDate(startDateString, includeOrdinals)
+  const formattedEndDate = formatDate(endDateString, includeOrdinals)
 
   if (
-    !dateIsToday(endDateString) &&
-    formattedStartDate.split(' ').slice(-1)[0] ===
-      formattedEndDate.split(' ').slice(-1)[0]
+    !dateStringIsToday(endDateString) &&
+    formattedDateYear(formattedStartDate) ===
+      formattedDateYear(formattedEndDate)
   ) {
     formattedStartDate = formattedStartDate.split(' ').slice(0, -1).join(' ')
 
@@ -65,6 +68,6 @@ export const formatDateRange = (
   }
 
   return `${formattedStartDate} to ${
-    dateIsToday(endDateString) ? 'now' : formattedEndDate
+    dateStringIsToday(endDateString) ? 'now' : formattedEndDate
   }`
 }

--- a/src/lib/formatDate.js
+++ b/src/lib/formatDate.js
@@ -19,27 +19,16 @@ const addOrdinal = () => {
   formattedDate = formattedDate.replace(dayAsString, suffixedDay)
 }
 
-export const formatDate = (dateString, includeOrdinal = false) => {
+export const formatDate = (
+  dateString,
+  includeOrdinal = false,
+  timezone = null
+) => {
   formattedDate = new Date(dateString).toLocaleDateString('en-GB', {
     day: 'numeric',
     month: 'long',
     year: 'numeric',
-  })
-
-  if (includeOrdinal) addOrdinal()
-
-  return formattedDate
-}
-
-export const formatDateTime = (dateString, includeOrdinal = false) => {
-  formattedDate = new Date(dateString).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-    // timeZone: 'UTC',
-    timeZoneName: 'long',
-    hour: 'numeric',
-    minute: 'numeric',
+    ...(timezone && { timezone: timezone }),
   })
 
   if (includeOrdinal) addOrdinal()
@@ -53,10 +42,15 @@ const dateIsToday = (dateString) =>
 export const formatDateRange = (
   startDateString,
   endDateString,
-  includeOrdinals = true
+  includeOrdinals = true,
+  timezone = null
 ) => {
-  let formattedStartDate = formatDate(startDateString, includeOrdinals)
-  const formattedEndDate = formatDate(endDateString, includeOrdinals)
+  let formattedStartDate = formatDate(
+    startDateString,
+    includeOrdinals,
+    timezone
+  )
+  const formattedEndDate = formatDate(endDateString, includeOrdinals, timezone)
 
   if (
     !dateIsToday(endDateString) &&

--- a/src/lib/formatDate.js
+++ b/src/lib/formatDate.js
@@ -45,7 +45,8 @@ export const formatDate = (dateString, includeOrdinal = false) => {
 const formattedDateYear = (formattedDate) =>
   formattedDate.split(' ').slice(-1)[0]
 
-const dateStringIsToday = (dateString) => usersDate === dateString
+const dateStringIsToday = (dateString) =>
+  new Date(usersDate).getTime() === new Date(dateString).getTime()
 
 export const formatDateRange = (
   startDateString,

--- a/src/lib/timelineData/index.js
+++ b/src/lib/timelineData/index.js
@@ -1,7 +1,7 @@
 import { countries } from '@/lib/placeNames'
 
 import { dates, arrival, departure, country, place } from './variables'
-import { beginningOfToday } from '../formatDate'
+import { usersDate } from '../formatDate'
 
 import { argentinaData } from './argentinaData'
 import { boliviaData } from './boliviaData'
@@ -60,8 +60,7 @@ const orderedTimelineArray = (startDate, endDate) => {
     Date.parse(stay[dates][departure]) >= Date.parse(startDate) &&
     Date.parse(stay[dates][arrival]) < Date.parse(endDate)
 
-  const stayIsFuture = (stay) =>
-    Date.parse(stay[dates][arrival]) >= beginningOfToday
+  const stayIsFuture = (stay) => stay[dates][arrival] >= usersDate
 
   const checkDateValidity = (stay, country, place) => {
     if (Date.parse(stay[dates][departure]) <= Date.parse(stay[dates][arrival]))

--- a/src/lib/timelineData/index.js
+++ b/src/lib/timelineData/index.js
@@ -57,13 +57,14 @@ const orderedTimelineArray = (startDate, endDate) => {
   let returnArray = []
 
   const stayIsInDateRange = (stay) =>
-    Date.parse(stay[dates][departure]) >= Date.parse(startDate) &&
-    Date.parse(stay[dates][arrival]) < Date.parse(endDate)
+    new Date(stay[dates][departure]) >= new Date(startDate) &&
+    new Date(stay[dates][arrival]) < new Date(endDate)
 
-  const stayIsFuture = (stay) => stay[dates][arrival] >= usersDate
+  const stayIsFuture = (stay) =>
+    new Date(stay[dates][arrival]) >= new Date(usersDate)
 
   const checkDateValidity = (stay, country, place) => {
-    if (Date.parse(stay[dates][departure]) <= Date.parse(stay[dates][arrival]))
+    if (new Date(stay[dates][departure]) <= new Date(stay[dates][arrival]))
       throw new Error(
         `Timeline ${place} ${country} stay arrival date of ${stay[dates][arrival]}
         is not before departure date of ${stay[dates][departure]}`
@@ -79,7 +80,7 @@ const orderedTimelineArray = (startDate, endDate) => {
             [country]: countryKey,
             [place]: placeKey,
             [arrival]:
-              Date.parse(startDate) > Date.parse(stay[dates][arrival])
+              new Date(startDate) > new Date(stay[dates][arrival])
                 ? startDate
                 : stay[dates][arrival],
             [departure]: stay[dates][departure],
@@ -89,7 +90,7 @@ const orderedTimelineArray = (startDate, endDate) => {
     })
   })
 
-  returnArray.sort((a, b) => Date.parse(b[arrival]) - Date.parse(a[arrival]))
+  returnArray.sort((a, b) => new Date(b[arrival]) - new Date(a[arrival]))
 
   checkDateOverlap(returnArray)
 
@@ -124,7 +125,7 @@ export const parsedTimelineData = (startDate, endDate) => {
     endDateIsSet = true
   } else {
     endDateIsSet = false
-    endDate = new Date().toJSON().slice(0, 10)
+    endDate = usersDate
   }
 
   let returnArray = []

--- a/src/lib/timelineData/thailandData/index.js
+++ b/src/lib/timelineData/thailandData/index.js
@@ -75,6 +75,12 @@ export const thailandData = {
         [departure]: '2023-04-06',
       },
     },
+    {
+      [dates]: {
+        [arrival]: '2023-11-09',
+        [departure]: '2023-11-16',
+      },
+    },
   ],
   [places[countries.thailand].kanchanaburi]: [
     {
@@ -219,6 +225,12 @@ export const thailandData = {
       [dates]: {
         [arrival]: '2013-05-01',
         [departure]: '2013-05-02',
+      },
+    },
+    {
+      [dates]: {
+        [arrival]: '2023-11-16',
+        [departure]: '2023-11-30',
       },
     },
   ],

--- a/src/pages/articles/what-to-pack-as-a-digital-nomad.mdx
+++ b/src/pages/articles/what-to-pack-as-a-digital-nomad.mdx
@@ -184,7 +184,7 @@ You should get cultery in any Airbnb, but its much less likely in a hotel room. 
 
 ### <ExternalLink url='https://www.amazon.co.uk/gp/product/B09WH3RY76'>Flat-pack silicone bowl</ExternalLink>
 
-Made popular by dogs, silicone bowls pack flat so they don't take up much space in your suitcase, but can be popped-out into a bowl whenever you feel like some granola or a fruit salad.
+Popularised by dogs, silicone bowls pack flat so they don't take up much space in your suitcase, but can be popped-out into a bowl whenever you feel like some granola or a fruit salad.
 
 ### Camping knife and sheath
 


### PR DESCRIPTION
I noticed a bug where, if I looked at the timeline after midnight here (in Bangkok), then rather than an ongoing stay having dates of `27th October 2023 to now` as expected, it had dates of `27th to 28th October 2023`.

### Expected

![0C48B27E-F5E1-481B-A778-078380AAAFF1_4_5005_c](https://github.com/jro31/slowmadding/assets/35604636/de944a87-0dde-4b69-b11f-732a11362567)

### Actual

![30107CB4-EE84-4669-A6BC-7BFB4CC18860_4_5005_c](https://github.com/jro31/slowmadding/assets/35604636/33aab0c6-fbe2-49d7-a03b-24fea66eeea9)

I believe this occurs because Thailand is 7 hours ahead of UTC time, and so from midnight until 7am, the [`dateIsToday`](https://github.com/jro31/slowmadding/blob/ae66390b0ad2ae856332746b24ce4f1217fb9678/src/lib/formatDate.js#L39) function (which is used to determine [whether we show a date or we show `now`](https://github.com/jro31/slowmadding/blob/ae66390b0ad2ae856332746b24ce4f1217fb9678/src/lib/formatDate.js#L68)) is comparing `new Date()`, which returns the current date/time in UTC, with a date string, for example `'2023-10-29'`.

Without setting the timezone, when using `toLocaleDateString`, `newDate()` will therefore be evaluated as 7 hours later than `'2023-10-29'` (within [`formatDate`](https://github.com/jro31/slowmadding/blob/ae66390b0ad2ae856332746b24ce4f1217fb9678/src/lib/formatDate.js#L27)).

This fix optionally allows a timezone to be passed to `formatDate`, and if it is, `toLocaleDateString` uses that timezone:

```js
formattedDate = new Date(dateString).toLocaleDateString('en-GB', {
  day: 'numeric',
  month: 'long',
  year: 'numeric',
  ...(timezone && { timezone: timezone }),
})
```

This, I think, will then evaluate the date string (for example `'2023-10-29'`) in UTC, so it will be comparable with `new Date()`.

The reason for my apprehension is I can't be arsed to stay up until midnight to test it, so creating a review app I'll hopefully wake up in the night to take a piss and can look then, but it fixes it in theory. In my head at least.

The `formatDateRange` function is also used by the `AccommodationTable` `Dates` component, where the dates are set as, for example `checkIn: '2022-10-07', checkOut: '2022-10-20',`. As these dates should read the same no matter where in the world someone happens to be reading the article (I don't want someone reading it in Mexico to see different dates to someone reading it in Thailand), I have not passed a timezone in here. That should, I think, leave the dates displaying as expected.

This PR also removes the `formatDateTime` function as it wasn't being used anywhere, and makes a slight tweak to the text of the `What to Pack as a Digital Nomad` article.