### PR TITLE
Add keywords to articles

### DIFF
--- a/src/components/ArticleLayout.jsx
+++ b/src/components/ArticleLayout.jsx
@@ -44,6 +44,10 @@ const ArticleLayout = ({
       <Head>
         <title>{meta.title}</title>
         <meta name="description" content={meta.description} />
+        <meta name="author" content="Jethro Williams" />
+        {meta.keywords && (
+          <meta name="keywords" content={meta.keywords.join(', ')} />
+        )}
       </Head>
       <Container className="mt-16 lg:mt-32">
         <div className="xl:relative">

--- a/src/pages/articles/athens-for-digital-nomads.mdx
+++ b/src/pages/articles/athens-for-digital-nomads.mdx
@@ -76,6 +76,7 @@ export const meta = {
   date: '2023-11-08T17:55:00+07:00',
   title: 'Athens for Digital Nomads',
   description: 'Known for its ruins and its history, how does Athens fare for the more modern lifestyle of a digital nomad?',
+  keywords: ['Greece'],
 }
 
 export const neosKosmosApartmentDetails = {

--- a/src/pages/articles/bangkok-for-digital-nomads.mdx
+++ b/src/pages/articles/bangkok-for-digital-nomads.mdx
@@ -125,6 +125,7 @@ export const meta = {
   date: '2023-07-05T21:00:00+03:00',
   title: 'Bangkok for Digital Nomads',
   description: "Bangkok is the travel hub of South-East Asia, but people often use it as nothing more than a stepping stone to get to Thailand's beaches or to Chiang Mai. How does it fare for the digital nomad who chooses to stop here?",
+  keywords: ['Thailand'],
 }
 
 export const nandhaHotelDetails = {

--- a/src/pages/articles/bucharest-for-digital-nomads.mdx
+++ b/src/pages/articles/bucharest-for-digital-nomads.mdx
@@ -51,6 +51,7 @@ export const meta = {
   date: '2023-07-26T13:05:00+03:00',
   title: 'Bucharest for Digital Nomads',
   description: "Romania is one of cheapest countries in the EU, so appealing to anyone with a European passport, but it's not in the Schengen zone, making it an ideal cooling-off destination for non-Europeans who've used their 90-day Schengen visa. What does its capital, Bucharest, offer for digital nomads?",
+  keywords: ['Romania'],
 }
 
 export const apartmentDetails = {

--- a/src/pages/articles/chiang-mai-for-digital-nomads.mdx
+++ b/src/pages/articles/chiang-mai-for-digital-nomads.mdx
@@ -31,6 +31,7 @@ export const meta = {
   date: '2023-02-03T15:13:00+07:00',
   title: 'Chiang Mai for Digital Nomads',
   description: "What's it like being a digital nomad in Chiang Mai? Read my thoughts on Chiang Mai as a digital nomad city, where I stayed, what the food was like, how to be sociable and where to run.",
+  keywords: ['Thailand'],
 }
 
 export const dewyHouseDetails = {

--- a/src/pages/articles/chiang-rai-for-digital-nomads.mdx
+++ b/src/pages/articles/chiang-rai-for-digital-nomads.mdx
@@ -40,6 +40,7 @@ export const meta = {
   date: '2023-01-27T15:18:15+07:00',
   title: 'Chiang Rai for Digital Nomads',
   description: "Chiang Rai is Thailand's often overlooked northern-most city, but what does that oversight mean for a digital nomad who likes a bit more peace and quiet?",
+  keywords: ['Thailand'],
 }
 
 export const saikeawResortDetails = {

--- a/src/pages/articles/getting-a-visa-extension-in-huahin.mdx
+++ b/src/pages/articles/getting-a-visa-extension-in-huahin.mdx
@@ -9,6 +9,7 @@ export const meta = {
   date: '2023-04-06T18:35:00+07:00',
   title: 'Getting a Visa Extension in Huahin',
   description: 'How do you extend your Thailand tourist visa in Huahin? How does it compare to doing it in other parts of the country?',
+  keywords: ['Thailand, Hua Hin'],
 }
 
 export const immigrationOfficeImages = [

--- a/src/pages/articles/getting-from-bangkok-to-huahin.mdx
+++ b/src/pages/articles/getting-from-bangkok-to-huahin.mdx
@@ -12,6 +12,7 @@ export const meta = {
   date: '2023-03-26T13:42:00+07:00',
   title: 'Getting from Bangkok to Huahin',
   description: "There are so many ways to travel from Bangkok to Huahin that it can be a little overwhelming. In this article I'll break it all down.",
+  keywords: ['Thailand, Hua Hin'],
 }
 
 export const stateRailwayOfThailandImages = [

--- a/src/pages/articles/ho-chi-minh-city-for-digital-nomads.mdx
+++ b/src/pages/articles/ho-chi-minh-city-for-digital-nomads.mdx
@@ -43,6 +43,7 @@ export const meta = {
   date: '2023-03-08T15:30:00+07:00',
   title: 'Ho Chi Minh City for Digital Nomads',
   description: 'Vietnam is somewhat of an outlier among South-East Asian countries. Ho Chi Minh City is its biggest city, so is the obvious choice to come as a digital nomad, but should you?',
+  keywords: ['Saigon', 'Vietnam'],
 }
 
 export const rivergateResidenceDetails = {

--- a/src/pages/articles/huahin-for-digital-nomads.mdx
+++ b/src/pages/articles/huahin-for-digital-nomads.mdx
@@ -48,6 +48,7 @@ export const meta = {
   date: '2023-11-16T10:00:00+07:00',
   title: 'Huahin for Digital Nomads',
   description: "Huahin doesn't get the same attention as other beach towns in Thailand, but how does it fare for digital nomads? Should you consider coming here instead of Phuket, Krabi or any of the islands?",
+  keywords: ['Thailand', 'Hua Hin'],
 }
 
 export const baanYokmhaneeFirstStayDetails = {

--- a/src/pages/articles/loei-for-digital-nomads.mdx
+++ b/src/pages/articles/loei-for-digital-nomads.mdx
@@ -44,6 +44,7 @@ export const meta = {
   date: '2023-05-19T16:35:00+07:00',
   title: 'Loei for Digital Nomads',
   description: "Loei is a small, non-touristy town in Isaan, far from the Farang trail in Thailand. Does that mean you should avoid it? Or is it actually a hidden gem and a secret digital nomad paradise?",
+  keywords: ['Thailand'],
 }
 
 export const loeiHuenHaoHugHomeAndResortDetails = {

--- a/src/pages/articles/phnom-penh-for-digital-nomads.mdx
+++ b/src/pages/articles/phnom-penh-for-digital-nomads.mdx
@@ -39,6 +39,7 @@ export const meta = {
   date: '2023-02-17T15:31:00+07:00',
   title: 'Phnom Penh for Digital Nomads',
   description: "Phnom Penh is Cambodia's capital and its biggest city, but how does that translate as a place for digital nomads?",
+  keywords: ['Cambodia'],
 }
 
 export const mResidenceDetails = {

--- a/src/pages/articles/siem-reap-for-digital-nomads.mdx
+++ b/src/pages/articles/siem-reap-for-digital-nomads.mdx
@@ -47,6 +47,7 @@ export const meta = {
   date: '2023-03-18T16:45:00+07:00',
   title: 'Siem Reap for Digital Nomads',
   description: 'Most people come to Siem Reap for a fleeting visit as a way to see Angkor Wat, but how does it stack-up if you stay longer term?',
+  keywords: ['Cambodia'],
 }
 
 export const chhaysPlaceDetails = {

--- a/src/pages/articles/sofia-for-digital-nomads.mdx
+++ b/src/pages/articles/sofia-for-digital-nomads.mdx
@@ -47,6 +47,7 @@ export const meta = {
   date: '2023-08-18T15:50:00+03:00',
   title: 'Sofia for Digital Nomads',
   description: "Bulgaria doesn't spring to mind when you think of tourist destinations in Europe, and its capital, Sofia, doesn't spring to mind when you think of tourist destinations in Bulgaria. Does that mean that it's not a good place for a digital nomad?",
+  keywords: ['Bulgaria'],
 }
 
 export const apartmentDetails = {

--- a/src/pages/articles/taking-a-bus-from-udon-thani-to-loei.mdx
+++ b/src/pages/articles/taking-a-bus-from-udon-thani-to-loei.mdx
@@ -15,6 +15,7 @@ export const meta = {
   date: '2023-05-07T20:45:00+07:00',
   title: 'Taking a Bus from Udon Thani to Loei',
   description: "Travelling from Udon Thani to Loei? There's a lot of misinformation about the locations and times of which buses depart. This article is everything I learned while figuring-out this journey for myself.",
+  keywords: ['Thailand'],
 }
 
 export const udonThaniBusTerminalsImages = [

--- a/src/pages/articles/travelling-from-phnom-penh-to-ho-chi-minh-city.mdx
+++ b/src/pages/articles/travelling-from-phnom-penh-to-ho-chi-minh-city.mdx
@@ -13,6 +13,7 @@ export const meta = {
   date: '2023-02-08T15:15:00+07:00',
   title: 'Travelling from Phnom Penh to Ho Chi Minh City',
   description: 'Thinking of travelling from Phnom Penh to Ho Chi Minh City? This article has everything you need to know about visas, travel and arriving in Ho Chi Minh.',
+  keywords: ['Cambodia, Saigon, Vietnam'],
 }
 
 export const giantIbisPhnomPenhTicketOfficeImages = [

--- a/src/pages/articles/udon-thani-for-digital-nomads.mdx
+++ b/src/pages/articles/udon-thani-for-digital-nomads.mdx
@@ -51,6 +51,7 @@ export const meta = {
   date: '2023-06-08T16:00:00+01:00',
   title: 'Udon Thani for Digital Nomads',
   description: "Udon Thani is one of the four 'big' cities located in Thailand's Isaan region, a huge area of the country largely ignored by foreign tourists. Not being ruined by tourism, Udon retains the friendliness that Thailand is famous for. Don't dismiss it just because everyone else does.",
+  keywords: ['Thailand'],
 }
 
 export const jamjureeHomeDetails = {


### PR DESCRIPTION
The primary purpose of this is that when I (eventually) get around to writing a search algorithm, which will filter articles by the words contained in the title and article headings, I also want to be able to set additional words that will return articles.

For example, I want the 'Bangkok for Digital Nomads' article to be returned if someone searches for `Thailand`, despite `Thailand` not being present in any of the article headings. Or for when a place has mutlple names. `Huahin` is also known as 'Hua Hin'. 'Ho Chi Minh City' is also know as 'Saigon', and even though I've opted to use 'Ho Chi Minh City' in my article, I want it to be responsive if someone searches for 'Saigon'.

As a bonus, I've added these keywords to a 'keyword' meta tag in the article header. This may or may not be of benefit, because in the past at least, search engines would punish web pages that gave keywords that weren't actually prominent in the article, so if I've given 'Hua Hin' as a keyword, but don't actually use it, is that going to be good or bad?

Taking the chance for now.