### PR TITLE
Improve image gallery touch functionality

### DIFF
--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -18,6 +18,8 @@ const ImageGallery = ({ images }) => {
 
   const [imageTouchStartX, setImageTouchStartX] = useState(null)
   const imageTouchStartXRef = useRef(imageTouchStartX)
+  const [imageTouchStartY, setImageTouchStartY] = useState(null)
+  const imageTouchStartYRef = useRef(imageTouchStartY)
 
   const [imageMouseDown, setImageMouseDown] = useState(false)
   const imageMouseDownRef = useRef(imageMouseDown)
@@ -46,33 +48,65 @@ const ImageGallery = ({ images }) => {
 
   useEffect(() => {
     const handleImageTouchStart = (event) => {
-      event.preventDefault()
-      if (imageIndexRef.current !== null)
+      if (images.length <= 1) return
+
+      if (imageIndexRef.current !== null) {
         setImageTouchStartX(event.changedTouches[0].screenX)
+        setImageTouchStartY(event.changedTouches[0].screenY)
+      }
+    }
+
+    const handleImageTouchMove = (event) => {
+      if (images.length <= 1) return
+
+      if (
+        imageIndexRef.current !== null &&
+        imageTouchStartXRef.current &&
+        imageTouchStartYRef.current
+      ) {
+        let XDifference = Math.abs(
+          event.changedTouches[0].screenX - imageTouchStartXRef.current
+        )
+        let YDifference = Math.abs(
+          event.changedTouches[0].screenY - imageTouchStartYRef.current
+        )
+        if (XDifference - YDifference > 10) {
+          event.preventDefault()
+        } else if (YDifference - XDifference > 10) {
+          setImageTouchStartX(null)
+          setImageTouchStartY(null)
+        }
+      }
     }
 
     const handleWindowTouchEnd = (event) => {
-      if (imageIndexRef.current !== null) {
-        if (
-          imageTouchStartXRef.current &&
-          event.changedTouches[0].screenX < imageTouchStartXRef.current
-        ) {
+      if (images.length <= 1) return
+
+      if (
+        imageIndexRef.current !== null &&
+        imageTouchStartXRef.current
+        // && Math.abs(event.changedTouches[0].screenX - imageTouchStartXRef.current) > 10
+      ) {
+        if (event.changedTouches[0].screenX < imageTouchStartXRef.current) {
           scrollImages('right')
         } else if (
-          imageTouchStartXRef.current &&
           event.changedTouches[0].screenX > imageTouchStartXRef.current
         ) {
           scrollImages('left')
         }
       }
       setImageTouchStartX(null)
+      setImageTouchStartY(null)
     }
 
     const handleImageMouseDown = () => {
+      if (images.length <= 1) return
+
       if (imageIndexRef.current !== null) setImageMouseDown(true)
     }
 
     const handleImageMouseOver = (event) => {
+      if (images.length <= 1) return
       if (imageIndexRef.current === null) return
 
       const rect = event.target.getBoundingClientRect()
@@ -92,10 +126,15 @@ const ImageGallery = ({ images }) => {
       }
     }
 
-    const handleImageMouseOut = () =>
+    const handleImageMouseOut = () => {
+      if (images.length <= 1) return
+
       imageOverlayRef.current.classList.remove('cursor-pointer')
+    }
 
     const handleWindowMouseUp = (event) => {
+      if (images.length <= 1) return
+
       if (imageIndexRef.current !== null) {
         if (!imageMouseDownRef.current) return
 
@@ -113,6 +152,7 @@ const ImageGallery = ({ images }) => {
 
     const currentImageOverlay = imageOverlayRef.current
     currentImageOverlay.addEventListener('touchstart', handleImageTouchStart)
+    currentImageOverlay.addEventListener('touchmove', handleImageTouchMove)
     window.addEventListener('touchend', handleWindowTouchEnd)
 
     currentImageOverlay.addEventListener('mousedown', handleImageMouseDown)
@@ -125,6 +165,7 @@ const ImageGallery = ({ images }) => {
         'touchstart',
         handleImageTouchStart
       )
+      currentImageOverlay.removeEventListener('touchmove', handleImageTouchMove)
       window.removeEventListener('touchend', handleWindowTouchEnd)
 
       currentImageOverlay.removeEventListener('mousedown', handleImageMouseDown)
@@ -141,6 +182,10 @@ const ImageGallery = ({ images }) => {
   useEffect(() => {
     imageTouchStartXRef.current = imageTouchStartX
   }, [imageTouchStartX])
+
+  useEffect(() => {
+    imageTouchStartYRef.current = imageTouchStartY
+  }, [imageTouchStartY])
 
   useEffect(() => {
     imageMouseDownRef.current = imageMouseDown

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -70,11 +70,13 @@ const ImageGallery = ({ images }) => {
         let YDifference = Math.abs(
           event.changedTouches[0].screenY - imageTouchStartYRef.current
         )
-        if (XDifference - YDifference > 10) {
-          event.preventDefault()
-        } else if (YDifference - XDifference > 10) {
+        let numberOfFingers = event.touches.length
+
+        if (numberOfFingers > 1 || YDifference - XDifference > 10) {
           setImageTouchStartX(null)
           setImageTouchStartY(null)
+        } else if (XDifference - YDifference > 10) {
+          event.preventDefault()
         }
       }
     }
@@ -82,11 +84,7 @@ const ImageGallery = ({ images }) => {
     const handleWindowTouchEnd = (event) => {
       if (images.length <= 1) return
 
-      if (
-        imageIndexRef.current !== null &&
-        imageTouchStartXRef.current
-        // && Math.abs(event.changedTouches[0].screenX - imageTouchStartXRef.current) > 10
-      ) {
+      if (imageIndexRef.current !== null && imageTouchStartXRef.current) {
         if (event.changedTouches[0].screenX < imageTouchStartXRef.current) {
           scrollImages('right')
         } else if (

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -70,14 +70,28 @@ const ImageGallery = ({ images }) => {
         let YDifference = Math.abs(
           event.changedTouches[0].screenY - imageTouchStartYRef.current
         )
-        let numberOfFingers = event.touches.length
 
-        if (numberOfFingers > 1 || YDifference - XDifference > 10) {
+        if (YDifference - XDifference > 10) {
           setImageTouchStartX(null)
           setImageTouchStartY(null)
         } else if (XDifference - YDifference > 10) {
           event.preventDefault()
         }
+      }
+    }
+
+    const handleWindowTouchMove = (event) => {
+      if (images.length <= 1) return
+
+      let numberOfFingers = event.touches.length
+
+      if (
+        numberOfFingers > 1 &&
+        imageTouchStartXRef.current &&
+        imageTouchStartYRef.current
+      ) {
+        setImageTouchStartX(null)
+        setImageTouchStartY(null)
       }
     }
 
@@ -151,6 +165,7 @@ const ImageGallery = ({ images }) => {
     const currentImageOverlay = imageOverlayRef.current
     currentImageOverlay.addEventListener('touchstart', handleImageTouchStart)
     currentImageOverlay.addEventListener('touchmove', handleImageTouchMove)
+    window.addEventListener('touchmove', handleWindowTouchMove)
     window.addEventListener('touchend', handleWindowTouchEnd)
 
     currentImageOverlay.addEventListener('mousedown', handleImageMouseDown)
@@ -164,6 +179,7 @@ const ImageGallery = ({ images }) => {
         handleImageTouchStart
       )
       currentImageOverlay.removeEventListener('touchmove', handleImageTouchMove)
+      window.removeEventListener('touchmove', handleWindowTouchMove)
       window.removeEventListener('touchend', handleWindowTouchEnd)
 
       currentImageOverlay.removeEventListener('mousedown', handleImageMouseDown)

--- a/src/components/ImageGallery.jsx
+++ b/src/components/ImageGallery.jsx
@@ -225,7 +225,7 @@ const ImageGallery = ({ images }) => {
         <div
           ref={imageOverlayRef}
           id="image-overlay"
-          className="absolute z-10 h-full w-full cursor-pointer"
+          className="absolute z-10 h-full w-full"
         />
 
         <div className="flex h-full items-center justify-center">


### PR DESCRIPTION
This PR adds tracking of image touches on the Y axis. The main purpose of this is to allow the page to scroll as normal when the user scrolls more vertically than horizontally on an image, but to prevent page scrolling and instead scroll the image stack when the user scrolls more horizontally than vertically.

In place of the `event.preventDefault()` in `handleImageTouchStart`, which is what previously prevented the page from scrolling when a user swiped on an image (no matter what direction they swiped), I've added the `handleImageTouchMove` function. This function checks whether scrolling on the X axis or the Y axis is greater. If it is greater on the X axis (by more than 10 to allow the user a bit of leeway in order to establish their gesture before acting), then `event.preventDefault()` is run to stop the page from scrolling. If it is greater on the Y axis (by more than 10), then the starting X value state is set to null, meaning `handleWindowTouchEnd` has no impact and the image stack doesn't scroll.