### PR TITLE
Hide `AccommodationTable` stays if more than three

### DIFF
--- a/src/components/AccommodationTable/index.jsx
+++ b/src/components/AccommodationTable/index.jsx
@@ -2,9 +2,13 @@ import BookingPlatform from './BookingPlatform'
 import Dates from './Dates'
 import PriceBreakdown from './PriceBreakdown'
 import RoomType from './RoomType'
+import { formatDate } from '@/lib/formatDate'
+import useNumberOfNights from '@/hooks/use-number-of-nights'
 
 const AccommodationTable = ({ stays }) => {
-  return stays.map((stay) => (
+  const numberOfNights = useNumberOfNights()
+
+  const stayTable = (stay) => (
     <div key={`${stay.dates.checkIn}-to-${stay.dates.checkOut}-accommodation`}>
       <div className="flex flex-col gap-5 sm:gap-2">
         <Dates dates={stay.dates} />
@@ -18,7 +22,31 @@ const AccommodationTable = ({ stays }) => {
         />
       </div>
     </div>
-  ))
+  )
+
+  if (stays.length >= 3) {
+    const totalNights = stays.reduce(
+      (sum, stay) =>
+        sum + numberOfNights(stay.dates.checkIn, stay.dates.checkOut),
+      0
+    )
+
+    return (
+      <>
+        <p>
+          I've stayed here {stays.length} times as a digital nomad, starting in
+          {` ${formatDate(stays[0].dates.checkIn, true)
+            .split(' ')
+            .slice(1)
+            .join(' ')}, `}
+          for a total of {totalNights} nights, most recently...
+        </p>
+        {stayTable(stays[stays.length - 1])}
+      </>
+    )
+  } else {
+    return stays.map((stay) => stayTable(stay))
+  }
 }
 
 export default AccommodationTable


### PR DESCRIPTION
If the number of `stays` submitted to the `AccommodationTable` is three or more, now rather than showing them all, we instead show a summary sentence and just the most recent stay.

<img width="859" alt="Screenshot 2025-03-19 at 19 53 50" src="https://github.com/user-attachments/assets/7bca82eb-8661-4d2c-87d6-f16bede4f476" />
